### PR TITLE
Retain Aseprite.app related content (prevent deletion)

### DIFF
--- a/.github/workflows/build_and_release.yaml
+++ b/.github/workflows/build_and_release.yaml
@@ -119,7 +119,7 @@ jobs:
       - name: Clean Up Build folder
         working-directory: aseprite/build/bin
         shell: bash
-        run: find . -mindepth 1 ! \( -name 'aseprite' -o -name 'aseprite.exe' -o -name 'data' -prune \) -exec rm -rf {} +
+        run: find . -mindepth 1 ! \( -name 'aseprite' -o -name 'aseprite.exe' -o -name 'data' -prune -o -name 'Aseprite.app' -prune \) -exec rm -rf {} +
       - name: Make portable zip
         working-directory: aseprite/build/bin
         run: echo '# This file is here so Aseprite behaves as a portable program' > aseprite.ini


### PR DESCRIPTION
In the `Clean Up Build folder` step, the builder removes all content except for aseprite-related files/directories. However, on macOS, the directory named `Aseprite.app` (specific to the macOS build) should also be preserved and not deleted during this cleanup process.