### PR TITLE
Restrict build matrix to Windows environment

### DIFF
--- a/.github/workflows/build_and_release.yaml
+++ b/.github/workflows/build_and_release.yaml
@@ -52,7 +52,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
         matrix:
-          os: [ windows-latest, ubuntu-latest, macOS-latest ]
+          os: [ windows-latest ]
         fail-fast: false
     steps:
       - name: Install Dependencies


### PR DESCRIPTION
Modified the build matrix to only include Windows for CI/CD workflows.