### PR TITLE
update actions and inject release version into source

### DIFF
--- a/.github/workflows/build_and_release.yaml
+++ b/.github/workflows/build_and_release.yaml
@@ -36,9 +36,10 @@ jobs:
       download-link: ${{ needs.fetch-aseprite-info.outputs.download-link }}
       release-tag: ${{ needs.fetch-aseprite-info.outputs.release-tag }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
       - uses: ncipollo/release-action@v1
         with:
+          name: Aseprite ${{ needs.fetch-aseprite-info.outputs.release-tag }}
           tag: ${{ needs.fetch-aseprite-info.outputs.release-tag }}
           body: Aseprite-${{ needs.fetch-aseprite-info.outputs.release-tag }}
           skipIfReleaseExists: true
@@ -64,11 +65,23 @@ jobs:
             libpixman-1-dev libfreetype6-dev libharfbuzz-dev zlib1g-dev \
             libx11-dev libxcursor-dev libxi-dev libxrandr-dev libgl1-mesa-dev \
             libfontconfig1-dev
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Install Aseprite
         shell: bash
         run: |
           git clone --recurse-submodules -j8 https://github.com/aseprite/aseprite --branch ${{ needs.create-release.outputs.release-tag }}
+      - name: Inject Release Version into Source
+        working-directory: aseprite
+        shell: bash
+        run: |
+          RELEASE_TAG="${{ needs.create-release.outputs.release-tag }}"
+          VERSION_NUM="${RELEASE_TAG#v}"
+          if [[ "${{ runner.os }}" == "macOS" ]]; then
+            sed -i '' "s/set(VERSION \"1.x-dev\")/set(VERSION \"${VERSION_NUM}\")/g" src/ver/CMakeLists.txt
+          else
+            sed -i "s/set(VERSION \"1.x-dev\")/set(VERSION \"${VERSION_NUM}\")/g" src/ver/CMakeLists.txt
+          fi
+          grep "set(VERSION" src/ver/CMakeLists.txt
       - name: Install Skia
         working-directory: aseprite
         shell: bash

--- a/.github/workflows/build_and_release_macOS_x86.yaml
+++ b/.github/workflows/build_and_release_macOS_x86.yaml
@@ -103,7 +103,7 @@ jobs:
       - name: Clean Up Build folder
         working-directory: aseprite/build/bin
         shell: bash
-        run: find . -mindepth 1 ! \( -name 'aseprite' -o -name 'aseprite.exe' -o -name 'data' -prune \) -exec rm -rf {} +
+        run: find . -mindepth 1 ! \( -name 'aseprite' -o -name 'aseprite.exe' -o -name 'data' -prune -o -name 'Aseprite.app' -prune \) -exec rm -rf {} +
       - name: Make portable zip
         working-directory: aseprite/build/bin
         run: echo '# This file is here so Aseprite behaves as a portable program' > aseprite.ini

--- a/.github/workflows/build_and_release_macOS_x86.yaml
+++ b/.github/workflows/build_and_release_macOS_x86.yaml
@@ -36,7 +36,7 @@ jobs:
       download-link: ${{ needs.fetch-aseprite-info.outputs.download-link }}
       release-tag: ${{ needs.fetch-aseprite-info.outputs.release-tag }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
       - uses: ncipollo/release-action@v1
         with:
           tag: ${{ needs.fetch-aseprite-info.outputs.release-tag }}
@@ -63,11 +63,23 @@ jobs:
           sudo apt-get install -y \
             libpixman-1-dev libfreetype6-dev libharfbuzz-dev zlib1g-dev \
             libx11-dev libxcursor-dev libxi-dev libgl1-mesa-dev libfontconfig1-dev
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Install Aseprite
         shell: bash
         run: |
           git clone --recurse-submodules -j8 https://github.com/aseprite/aseprite --branch ${{ needs.create-release.outputs.release-tag }}
+      - name: Inject Release Version into Source
+        working-directory: aseprite
+        shell: bash
+        run: |
+          RELEASE_TAG="${{ needs.create-release.outputs.release-tag }}"
+          VERSION_NUM="${RELEASE_TAG#v}"
+          if [[ "${{ runner.os }}" == "macOS" ]]; then
+            sed -i '' "s/set(VERSION \"1.x-dev\")/set(VERSION \"${VERSION_NUM}\")/g" src/ver/CMakeLists.txt
+          else
+            sed -i "s/set(VERSION \"1.x-dev\")/set(VERSION \"${VERSION_NUM}\")/g" src/ver/CMakeLists.txt
+          fi
+          grep "set(VERSION" src/ver/CMakeLists.txt
       - name: Install Skia
         working-directory: aseprite
         shell: bash


### PR DESCRIPTION
- Bump `actions/checkout` to `v6`
- Add a release name to the release action
- Add "Inject Release Version into Source" step to both workflows (`build_and_release.yaml` & `build_and_release_macOS_x86.yaml`):
  - Clone Aseprite source and extract numeric version from the release tag (stripping 'v')
  - Replace `set(VERSION "1.x-dev")` in `src/ver/CMakeLists.txt` with the tag version using `sed` (handles macOS inplace syntax)
  - Verify the version replacement with `grep`
  - Reason: Ensures the compiled Aseprite application displays the actual release version in the main window title bar instead of the default "1.x-dev"